### PR TITLE
Add in-memory storage filtering tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "npx vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "npm run db:push && cross-env NODE_ENV=production node dist/index.js",
-    "check": "tsc",
+    "check": "tsc && npm run test",
+    "test": "tsx --test \"server/__tests__/**/*.test.ts\"",
     "db:push": "drizzle-kit push",
     "db:setup": "node scripts/setup-local-db.js",
     "deploy:prepare": "node scripts/prepare-deploy.mjs"

--- a/server/__tests__/storage.filters.test.ts
+++ b/server/__tests__/storage.filters.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DatabaseStorage } from '../storage';
+import type { Inspection } from '@shared/schema';
+
+const createInspection = (overrides: Partial<Inspection> & { id: number; numero: string }): Inspection => {
+  const baseDate = new Date('2023-01-01T00:00:00Z');
+
+  return {
+    id: overrides.id,
+    numero: overrides.numero,
+    unidadeInspecionada: overrides.unidadeInspecionada ?? 'Delegacia A',
+    departamento: overrides.departamento ?? 'Operações',
+    coorpin: overrides.coorpin ?? 'COORPIN 01',
+    dataInspecao: overrides.dataInspecao ?? baseDate,
+    delegadoCorregedor: overrides.delegadoCorregedor ?? 'Delegado Responsável',
+    naoConformidade: overrides.naoConformidade ?? 'Infraestrutura',
+    descricaoNaoConformidade: overrides.descricaoNaoConformidade ?? 'Descrição padrão',
+    providenciasIniciais: overrides.providenciasIniciais ?? null,
+    providenciasIntermediarias: overrides.providenciasIntermediarias ?? null,
+    providenciasConclusivas: overrides.providenciasConclusivas ?? null,
+    dataInicioPrazo: overrides.dataInicioPrazo ?? null,
+    diasPrazo: overrides.diasPrazo ?? null,
+    dataFimRegularizacao: overrides.dataFimRegularizacao ?? null,
+    statusPrazo: overrides.statusPrazo ?? 'regularizado',
+    dataDeterminadaNovaInspecao: overrides.dataDeterminadaNovaInspecao ?? null,
+    criticidade: overrides.criticidade ?? null,
+    createdAt: overrides.createdAt ?? baseDate,
+    updatedAt: overrides.updatedAt ?? baseDate,
+  };
+};
+
+const buildMockInspections = (): Inspection[] => [
+  createInspection({
+    id: 1,
+    numero: '001',
+    unidadeInspecionada: 'Delegacia A',
+    departamento: 'Operações',
+    naoConformidade: 'Infraestrutura',
+    dataInspecao: new Date('2023-01-10T00:00:00Z'),
+    statusPrazo: 'regularizado',
+  }),
+  createInspection({
+    id: 2,
+    numero: '002',
+    unidadeInspecionada: 'Delegacia B',
+    departamento: 'Administrativo',
+    naoConformidade: 'Documentação',
+    dataInspecao: new Date('2023-05-15T00:00:00Z'),
+    statusPrazo: 'pendente',
+  }),
+  createInspection({
+    id: 3,
+    numero: '003',
+    unidadeInspecionada: 'Delegacia A',
+    departamento: 'Administrativo',
+    naoConformidade: 'Infraestrutura',
+    dataInspecao: new Date('2024-02-20T00:00:00Z'),
+    statusPrazo: 'nao_regularizado',
+  }),
+  createInspection({
+    id: 4,
+    numero: '004',
+    unidadeInspecionada: 'Delegacia C',
+    departamento: 'Operações',
+    naoConformidade: 'Equipamentos',
+    dataInspecao: new Date('2024-08-05T00:00:00Z'),
+    statusPrazo: 'pendente',
+  }),
+];
+
+describe('DatabaseStorage.getInspectionsByFilters', () => {
+  let storage: DatabaseStorage;
+
+  beforeEach(() => {
+    storage = new DatabaseStorage();
+    (storage as unknown as { inMemoryInspections: Inspection[] }).inMemoryInspections = buildMockInspections();
+  });
+
+  it('retorna todas as inspeções quando nenhum filtro é informado', async () => {
+    const inspections = await storage.getInspectionsByFilters({});
+    assert.equal(inspections.length, 4);
+  });
+
+  it('filtra por unidade inspecionada', async () => {
+    const inspections = await storage.getInspectionsByFilters({ unidade: ['Delegacia A'] });
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      assert.equal(inspection.unidadeInspecionada, 'Delegacia A');
+    });
+  });
+
+  it('filtra por departamento', async () => {
+    const inspections = await storage.getInspectionsByFilters({ departamento: ['Administrativo'] });
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      assert.equal(inspection.departamento, 'Administrativo');
+    });
+  });
+
+  it('filtra por não conformidade', async () => {
+    const inspections = await storage.getInspectionsByFilters({ naoConformidade: ['Infraestrutura'] });
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      assert.equal(inspection.naoConformidade, 'Infraestrutura');
+    });
+  });
+
+  it('filtra pelo ano da inspeção', async () => {
+    const inspections = await storage.getInspectionsByFilters({ ano: 2024 });
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      assert.equal(new Date(inspection.dataInspecao).getUTCFullYear(), 2024);
+    });
+  });
+
+  it('filtra por intervalo de datas', async () => {
+    const inspections = await storage.getInspectionsByFilters({
+      dataInicial: new Date('2023-01-01T00:00:00Z'),
+      dataFinal: new Date('2023-12-31T23:59:59Z'),
+    });
+
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      const inspectionDate = new Date(inspection.dataInspecao).getTime();
+      assert.ok(inspectionDate >= new Date('2023-01-01T00:00:00Z').getTime());
+      assert.ok(inspectionDate <= new Date('2023-12-31T23:59:59Z').getTime());
+    });
+  });
+
+  it('filtra por status do prazo', async () => {
+    const inspections = await storage.getInspectionsByFilters({ statusPrazo: 'pendente' });
+    assert.equal(inspections.length, 2);
+    inspections.forEach((inspection) => {
+      assert.equal(inspection.statusPrazo, 'pendente');
+    });
+  });
+
+  it('combina múltiplos filtros simultaneamente', async () => {
+    const inspections = await storage.getInspectionsByFilters({
+      unidade: ['Delegacia A'],
+      departamento: ['Administrativo'],
+      naoConformidade: ['Infraestrutura'],
+      ano: 2024,
+      dataInicial: new Date('2024-01-01T00:00:00Z'),
+      dataFinal: new Date('2024-12-31T23:59:59Z'),
+      statusPrazo: 'nao_regularizado',
+    });
+
+    assert.equal(inspections.length, 1);
+    assert.equal(inspections[0]?.numero, '003');
+  });
+});


### PR DESCRIPTION
## Summary
- add an in-memory filtering path to DatabaseStorage so filters work without a database connection
- create node:test coverage for getInspectionsByFilters across individual and combined filters
- expose an npm test script that runs the new suite via tsx and hook it into the existing check routine

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb0a7cc5c88328a09fa676d071f64a

---

<!-- kody-pr-summary:start -->
Este pull request implementa a funcionalidade de filtragem para dados de inspeção armazenados em memória, complementando a lógica de filtragem existente para o banco de dados.

As principais mudanças incluem:

*   **Adição de armazenamento em memória:** A classe `DatabaseStorage` agora inclui uma propriedade `inMemoryInspections` para armazenar dados de inspeção quando nenhuma URL de banco de dados é configurada.
*   **Suporte a filtros em memória:** O método `getInspectionsByFilters` foi atualizado para aplicar a lógica de filtragem aos dados `inMemoryInspections` quando o aplicativo está operando sem um banco de dados externo.
*   **Novo método `filterInMemoryInspections`:** Um método privado foi adicionado para encapsular a lógica de filtragem para os dados em memória, suportando filtros por unidade, departamento, não conformidade, ano, intervalo de datas e status do prazo.
*   **Testes abrangentes:** Foram adicionados novos testes unitários (`server/__tests__/storage.filters.test.ts`) para verificar o correto funcionamento da filtragem em memória para todos os critérios suportados, incluindo a combinação de múltiplos filtros.

Essa alteração garante que a funcionalidade de filtragem de inspeções esteja disponível e seja consistente, independentemente de um banco de dados externo estar configurado ou se o armazenamento em memória estiver sendo utilizado.
<!-- kody-pr-summary:end -->